### PR TITLE
Add PR into example.spec.ts 

### DIFF
--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -11,6 +11,7 @@ test('get started link', async ({ page }) => {
   await page.goto('https://playwright.dev/');
   await expect(page.getByRole('link', { name: 'Docs' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'API' })).toBeVisible();
+  await expect(page.getByRole('link',{ name: 'PR' })).toBeVisible()
   // Click the get started link.
   await page.getByRole('link', { name: 'Get started' }).click();
 


### PR DESCRIPTION
I added: 
  await expect(page.getByRole('link',{ name: 'PR' })).toBeVisible()
Into 'example.spec.ts'  of 'tests' file 